### PR TITLE
Correct bug in compilation of 'test' when using coarrays$

### DIFF
--- a/{{ cookiecutter.project_slug }}/test/meson.build
+++ b/{{ cookiecutter.project_slug }}/test/meson.build
@@ -12,5 +12,9 @@ testapp_exe = executable(
   'testapp',
   sources: testapp_sources,
   dependencies: testapp_deps,
+{% if cookiecutter.__coarray_code == "True" -%}
+  fortran_args: coarray_compile_flags,
+  link_args: coarray_link_flags,
+{% endif %}
 )
 test('testapp', testapp_exe)


### PR DESCRIPTION
With the initial meson.build of "test"; compilation of the test app fails with the following error
```
[40/42] Compiling Fortran object test/testapp.p/testapp.f90.o
FAILED: test/testapp.p/testapp.f90.o 
gfortran -Itest/testapp.p -Itest -I../test -Isubprojects/fortuno/libfortuno.so.0.1.0.p -Isubprojects/fortuno-coarray/libfortuno-coarray.so.0.1.0.p -Isrc/libbugcookiecutter.so.0.1.0.p -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -std=f2018 -O0 -g -Jtest/testapp.p -o test/testapp.p/testapp.f90.o -c ../test/testapp.f90
../test/testapp.f90:2:15:

    2 | program testapp
      |               1
Fatal Error: Coarrays disabled at (1), use ‘-fcoarray=’ to enable
```
I have just copied the missing options from the "app" meson.build